### PR TITLE
Release/v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Please report any issue using github issues : https://github.com/Slivo-fr/TranqR
 - Display the frenzy cooldown of each boss
 - Optional automatic backup call when incapacitated
 - Optional automatic timed backup call 
+- Prints to chat name and reason of a tranq fail (miss or resist)
 
 ## Usage
  
@@ -53,6 +54,8 @@ The reset button is also able to resync raid hunters and rotation setup if you n
 You may adds the `/tranq backup` command to a macro that you can use when you are unable to tranq and you need some help,
 It will whisper all backup hunters the fail message.
 
+The `/tranq check` command allows you to list version or TranqRotate used by others hunters and others non-hunters players
+
 ## Roadmap
 
 Here is a list of feature I want to implement at some point, no specific order is decided yet.
@@ -60,6 +63,8 @@ Here is a list of feature I want to implement at some point, no specific order i
 - Automatic handling of death and disconnection of hunters on the rotation group (swap with a backup, send an alert about it)
 - Use raid symbols to mark hunters that need to tranq, or that need to backup a failed tranqshot
 - Automatic reset of rotation when raid wipe
+- Adds raid markers to tranq announces if target has one
+- Show an indicator on hunters that does not use TranqRotate (So you know you have to inform them about the rotation)
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please report any issue using github issues : https://github.com/Slivo-fr/TranqR
 - Display the list of raid hunters
 - Display offline and dead status on hunters frames
 - Allow player to re-order players between two groups : main rotation and backup
-- Synchronize rotation order between player using the addon
+- Synchronize rotation order between addon users
 - Allow player to broadcast the configured rotation and backup group to the raid
 - Provide a real time visual feedback about the rotation status, even if no one else use the addon in your raid
 - Synchronize tranqshot casts to other player using the addon

--- a/TranqRotate.toc
+++ b/TranqRotate.toc
@@ -35,3 +35,4 @@ src\defaults.lua
 src\settings.lua
 src\utils.lua
 src\debuff.lua
+src\migration.lua

--- a/TranqRotate.toc
+++ b/TranqRotate.toc
@@ -1,8 +1,8 @@
 ## Interface: 11307
-## Title: TranqRotate |cff00aa001.5.1|r
+## Title: TranqRotate |cff00aa001.6.0|r
 ## Notes: A tranqshot rotation assistant
 ## Author: Slivo
-## Version: 1.5.1
+## Version: 1.6.0
 ## SavedVariables: TranqRotateDb
 ## OptionalDeps: Ace3
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 #### v1.6.0
 
-- Improve miss and resist tranqshot handling (no more duplicate calls)
+- Improve miss and resist tranqshot handling (no more duplicate announces)
 - Adds gluth fear to handled list of incapacitating debuffs
 - Adds `/tranq check` command to display the version others users have installed
 - Fixed timed alert feature that never worked (forgot to call it :D)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 ## TranqRotate Changelog
 
+#### v1.6.0
+
+- Improve miss and resist tranqshot handling (no more duplicate calls)
+- Adds gluth fear to handled list of incapacitating debuffs
+- Adds `/tranq check` command to display the version others users have installed
+- Fixed timed alert feature that never worked (forgot to call it :D)
+- Fix an ui error when trying to send announces on say/yell channel in open world (test mode)
+
 #### v1.5.1
 
 - Handles the new dispel resistance mechanic

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,10 @@
 
 #### v1.6.0
 
-- Improves miss and resist tranqshot handling (no more duplicate announces)
+- Improves miss and resist tranqshot handling (no more duplicate announces or whispers)
 - Adds gluth fear to handled list of incapacitating debuffs
 - Adds `/tranq check` command to display the version other users have installed
+- Adds printing of fail to chat window
 - Fix timed alert feature that never worked (forgot to call it :D), changed default value to disabled
 - Fix an ui error when trying to send announces on say/yell channel in open world (test mode)
 - Fix windows hiding unexpectedly when changing settings

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,12 @@
 
 #### v1.6.0
 
-- Improve miss and resist tranqshot handling (no more duplicate announces)
+- Improves miss and resist tranqshot handling (no more duplicate announces)
 - Adds gluth fear to handled list of incapacitating debuffs
-- Adds `/tranq check` command to display the version others users have installed
-- Fixed timed alert feature that never worked (forgot to call it :D)
+- Adds `/tranq check` command to display the version other users have installed
+- Fix timed alert feature that never worked (forgot to call it :D), changed default value to disabled
 - Fix an ui error when trying to send announces on say/yell channel in open world (test mode)
+- Fix windows hiding unexpectedly when changing settings
 
 #### v1.5.1
 

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -45,6 +45,7 @@ local L = {
     ["SETTING_ANNOUNCES"] = "Announces",
     ["ENABLE_ANNOUNCES"] = "Enable announces",
     ["ENABLE_ANNOUNCES_DESC"] = "Enable / disable the announcement.",
+    ["YELL_SAY_DISABLED_OPEN_WORLD"] = "(Yell and say channels does not work in open world, but will inside your raids)",
 
     ---- Channels
     ["ANNOUNCES_CHANNEL_HEADER"] = "Announce channel",

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -1,4 +1,4 @@
-local TranqRotate = select(2, ...)
+TranqRotate = select(2, ...)
 
 local L = {
 

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -1,6 +1,6 @@
 if (GetLocale() ~= "frFR") then return end
 
-local TranqRotate = select(2, ...)
+TranqRotate = select(2, ...)
 
 local L = {
 

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -47,6 +47,7 @@ local L = {
     ["SETTING_ANNOUNCES"] = "Annonces",
     ["ENABLE_ANNOUNCES"] = "Activer les annonces",
     ["ENABLE_ANNOUNCES_DESC"] = "Activer / désactiver les annonces",
+    ["YELL_SAY_DISABLED_OPEN_WORLD"] = "(Les canaux dire et crier ne fonctionnent pas hors instance)",
 
     ---- Channels
     ["ANNOUNCES_CHANNEL_HEADER"] = "Canal",

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -1,6 +1,6 @@
 if (GetLocale() ~= "ruRU") then return end
 
-local TranqRotate = select(2, ...)
+TranqRotate = select(2, ...)
 
 local L = {
 

--- a/locales/ruRU.lua
+++ b/locales/ruRU.lua
@@ -47,6 +47,7 @@ local L = {
     ["SETTING_ANNOUNCES"] = "Оповещения",
     ["ENABLE_ANNOUNCES"] = "Включить оповещения",
     ["ENABLE_ANNOUNCES_DESC"] = "Включить / отключить оповещения",
+    ["YELL_SAY_DISABLED_OPEN_WORLD"] = "(Yell and say channels does not work in open world, but will inside your raids)",
 
     ---- Channels
     ["ANNOUNCES_CHANNEL_HEADER"] = "Канал оповещений",

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -1,6 +1,6 @@
 if (GetLocale() ~= "zhCN") then return end
 
-local TranqRotate = select(2, ...)
+TranqRotate = select(2, ...)
 
 local L = {
 

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -47,6 +47,7 @@ local L = {
     ["SETTING_ANNOUNCES"] = "通告",
     ["ENABLE_ANNOUNCES"] = "启用通告",
     ["ENABLE_ANNOUNCES_DESC"] = "启用 / 禁用通告",
+    ["YELL_SAY_DISABLED_OPEN_WORLD"] = "(Yell and say channels does not work in open world, but will inside your raids)",
 
     ---- Channels
     ["ANNOUNCES_CHANNEL_HEADER"] = "通告频道",

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -47,6 +47,7 @@ local L = {
     ["SETTING_ANNOUNCES"] = "通告",
     ["ENABLE_ANNOUNCES"] = "啟用通告",
     ["ENABLE_ANNOUNCES_DESC"] = "啟用 / 禁用通告",
+    ["YELL_SAY_DISABLED_OPEN_WORLD"] = "(Yell and say channels does not work in open world, but will inside your raids)",
 
     ---- Channels
     ["ANNOUNCES_CHANNEL_HEADER"] = "通告頻道",

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -1,6 +1,6 @@
 if (GetLocale() ~= "zhTW") then return end
 
-local TranqRotate = select(2, ...)
+TranqRotate = select(2, ...)
 
 local L = {
 

--- a/src/comms.lua
+++ b/src/comms.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 local AceComm = LibStub("AceComm-3.0")
 local AceSerializer = LibStub("AceSerializer-3.0")
 

--- a/src/comms.lua
+++ b/src/comms.lua
@@ -130,10 +130,13 @@ function TranqRotate:receiveSyncTranq(prefix, message, channel, sender)
         return
     end
 
-    local notDuplicate = hunter.lastTranqTime <  GetTime() - TranqRotate.constants.duplicateTranqshotDelayThreshold
-
-    if (notDuplicate) then
-        TranqRotate:rotate(hunter, message.fail)
+    if (not message.fail) then
+        local notDuplicate = hunter.lastTranqTime <  GetTime() - TranqRotate.constants.duplicateTranqshotDelayThreshold
+        if (notDuplicate) then
+            TranqRotate:rotate(hunter)
+        end
+    else
+        TranqRotate:handleFailTranq(hunter)
     end
 end
 

--- a/src/comms.lua
+++ b/src/comms.lua
@@ -65,12 +65,13 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 
 -- Broadcast a tranqshot event
-function TranqRotate:sendSyncTranq(hunter, fail, timestamp)
+function TranqRotate:sendSyncTranq(hunter, fail, timestamp, failEvent)
     local message = {
         ['type'] = TranqRotate.constants.commsTypes.tranqshotDone,
         ['timestamp'] = timestamp,
         ['player'] = hunter.name,
         ['fail'] = fail,
+        ['failEvent'] = failEvent,
     }
 
     TranqRotate:sendRaidAddonMessage(message)
@@ -138,7 +139,7 @@ function TranqRotate:receiveSyncTranq(prefix, message, channel, sender)
             TranqRotate:rotate(hunter)
         end
     else
-        TranqRotate:handleFailTranq(hunter)
+        TranqRotate:handleFailTranq(hunter, message.failEvent)
     end
 end
 

--- a/src/comms.lua
+++ b/src/comms.lua
@@ -85,7 +85,8 @@ function TranqRotate:sendSyncOrder(whisper, name)
     local message = {
         ['type'] = TranqRotate.constants.commsTypes.syncOrder,
         ['version'] = TranqRotate.syncVersion,
-        ['rotation'] = TranqRotate:getSimpleRotationTables()
+        ['rotation'] = TranqRotate:getSimpleRotationTables(),
+        ['addonVersion'] = TranqRotate.version,
     }
 
     if (whisper) then
@@ -100,6 +101,7 @@ function TranqRotate:sendSyncOrderRequest()
 
     local message = {
         ['type'] = TranqRotate.constants.commsTypes.syncRequest,
+        ['addonVersion'] = TranqRotate.version,
     }
 
     TranqRotate:sendRaidAddonMessage(message)
@@ -144,6 +146,7 @@ end
 function TranqRotate:receiveSyncOrder(prefix, message, channel, sender)
 
     TranqRotate:updateRaidStatus()
+    TranqRotate:updatePlayerAddonVersion(sender, message.addonVersion)
 
     if (TranqRotate:isVersionEligible(message.version, sender)) then
         TranqRotate.syncVersion = (message.version)
@@ -155,7 +158,8 @@ function TranqRotate:receiveSyncOrder(prefix, message, channel, sender)
 end
 
 -- Request to send current roration configuration received
-function TranqRotate:receiveSyncRequest(prefix, data, channel, sender)
+function TranqRotate:receiveSyncRequest(prefix, message, channel, sender)
+    TranqRotate:updatePlayerAddonVersion(sender, message.addonVersion)
     TranqRotate:sendSyncOrder(true, sender)
 end
 

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -27,6 +27,7 @@ TranqRotate.constants = {
 
     ['printPrefix'] = 'TranqRotate - ',
     ['duplicateTranqshotDelayThreshold'] = 10,
+    ['duplicateFailedTranqshotDelayThreshold'] = 10,
 
     ['minimumCooldownElapsedForEligibility'] = 10,
 

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -76,5 +76,6 @@ TranqRotate.constants = {
         19408, -- Magmadar fear
         23171, -- Chromaggus Bronze affliction stun
         23311, -- Chromaggus Time lapse
+        29685, -- Gluth fear
     },
 }

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 TranqRotate.colors = {
     ['green'] = CreateColor(0.67, 0.83, 0.45),
     ['darkGreen'] = CreateColor(0.1, 0.4, 0.1),

--- a/src/debuff.lua
+++ b/src/debuff.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 -- Checks if player is incapacitated by a debuff for too long
 function TranqRotate:isPlayedIncapacitatedByDebuff()
 

--- a/src/defaults.lua
+++ b/src/defaults.lua
@@ -23,7 +23,6 @@ function TranqRotate:LoadDefaults()
 			incapacitatedDelay = 2,
 			enableTimedBackupAlert = false,
 			timedBackupAlertDelay = 3,
-			currentMigration = #TranqRotate.migrations,
 	    },
 	}
 end

--- a/src/defaults.lua
+++ b/src/defaults.lua
@@ -20,9 +20,10 @@ function TranqRotate:LoadDefaults()
 			showWindowWhenTargetingBoss = false,
 			showFrenzyCooldownProgress = true,
 			enableIncapacitatedBackupAlert = true,
-			incapacitatedDelay = 1.5,
-			enableTimedBackupAlertValue = true,
-			timedBackupAlertValueDelay = 1.5,
+			incapacitatedDelay = 2,
+			enableTimedBackupAlert = false,
+			timedBackupAlertDelay = 3,
+			currentMigration = #TranqRotate.migrations,
 	    },
 	}
 end

--- a/src/dragdrop.lua
+++ b/src/dragdrop.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 -- Enable drag & drop for all hunter frames
 function TranqRotate:toggleListSorting(allowSorting)
     for key,hunter in pairs(TranqRotate.hunterTable) do

--- a/src/events.lua
+++ b/src/events.lua
@@ -45,8 +45,8 @@ function TranqRotate:COMBAT_LOG_EVENT_UNFILTERED()
                 TranqRotate:sendAnnounceMessage(TranqRotate.db.profile.announceSuccessMessage, destName)
             end
         elseif (event == "SPELL_MISSED" or event == "SPELL_DISPEL_FAILED") then
-            TranqRotate:sendSyncTranq(hunter, true, timestamp)
-            TranqRotate:handleFailTranq(hunter)
+            TranqRotate:sendSyncTranq(hunter, true, timestamp, event)
+            TranqRotate:handleFailTranq(hunter, event)
             if  (sourceGUID == UnitGUID("player")) then
                 TranqRotate:sendAnnounceMessage(TranqRotate.db.profile.announceFailMessage, destName)
             end

--- a/src/events.lua
+++ b/src/events.lua
@@ -29,25 +29,26 @@ function TranqRotate:COMBAT_LOG_EVENT_UNFILTERED()
 
     -- @todo : Improve this with register / unregister event to save resources
     -- Avoid parsing combat log when not able to use it
-    if not TranqRotate.raidInitialized then return end
+    if (not TranqRotate.raidInitialized) then return end
     -- Avoid parsing combat log when outside instance if test mode isn't enabled
-    if not TranqRotate.testMode and not IsInInstance() then return end
+    if (not TranqRotate.testMode and not IsInInstance()) then return end
 
     local timestamp, event, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo()
     local spellId, spellName, spellSchool, amount, overkill, school, resisted, blocked, absorbed, critical, glancing, crushing, isOffHand = select(12, CombatLogGetCurrentEventInfo())
 
-    -- @todo try to refactor a bit
     if (spellName == tranqShot or (TranqRotate.testMode and spellName == arcaneShot)) then
         local hunter = TranqRotate:getHunter(nil, sourceGUID)
         if (event == "SPELL_CAST_SUCCESS") then
             TranqRotate:sendSyncTranq(hunter, false, timestamp)
-            TranqRotate:rotate(hunter, false)
+            TranqRotate:rotate(hunter)
             if  (sourceGUID == UnitGUID("player")) then
                 TranqRotate:sendAnnounceMessage(TranqRotate.db.profile.announceSuccessMessage, destName)
             end
         elseif (event == "SPELL_MISSED" or event == "SPELL_DISPEL_FAILED") then
+            -- @Todo remove this when releasing beta
+            print(event)
             TranqRotate:sendSyncTranq(hunter, true, timestamp)
-            TranqRotate:rotate(hunter, true)
+            TranqRotate:handleFailTranq(hunter)
             if  (sourceGUID == UnitGUID("player")) then
                 TranqRotate:sendAnnounceMessage(TranqRotate.db.profile.announceFailMessage, destName)
             end

--- a/src/events.lua
+++ b/src/events.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 local tranqShot = GetSpellInfo(19801)
 local arcaneShot = GetSpellInfo(14287)
 

--- a/src/events.lua
+++ b/src/events.lua
@@ -45,8 +45,6 @@ function TranqRotate:COMBAT_LOG_EVENT_UNFILTERED()
                 TranqRotate:sendAnnounceMessage(TranqRotate.db.profile.announceSuccessMessage, destName)
             end
         elseif (event == "SPELL_MISSED" or event == "SPELL_DISPEL_FAILED") then
-            -- @Todo remove this when releasing beta
-            print(event)
             TranqRotate:sendSyncTranq(hunter, true, timestamp)
             TranqRotate:handleFailTranq(hunter)
             if  (sourceGUID == UnitGUID("player")) then

--- a/src/events.lua
+++ b/src/events.lua
@@ -66,7 +66,9 @@ function TranqRotate:COMBAT_LOG_EVENT_UNFILTERED()
             local type, id = TranqRotate:getIdFromGuid(sourceGUID)
             TranqRotate:startBossFrenzyCooldown(TranqRotate.constants.bosses[id].cooldown)
         end
-    elseif event == "UNIT_DIED" and TranqRotate:isTranqableBoss(destGUID) then
+    elseif (event == "SPELL_AURA_REMOVED" and TranqRotate:isBossFrenzy(spellName, sourceGUID)) then
+        TranqRotate.frenzy = false
+    elseif (event == "UNIT_DIED" and TranqRotate:isTranqableBoss(destGUID)) then
         TranqRotate:resetRotation()
         TranqRotate.mainFrame.frenzyFrame:Hide()
     end

--- a/src/events.lua
+++ b/src/events.lua
@@ -55,6 +55,7 @@ function TranqRotate:COMBAT_LOG_EVENT_UNFILTERED()
     elseif (event == "SPELL_AURA_APPLIED" and TranqRotate:isBossFrenzy(spellName, sourceGUID)) then
         TranqRotate.frenzy = true
         if (TranqRotate:isPlayerNextTranq()) then
+            TranqRotate:handleTimedAlert()
             TranqRotate:throwTranqAlert()
 
             if (TranqRotate.db.profile.enableIncapacitatedBackupAlert and TranqRotate:isPlayedIncapacitatedByDebuff()) then

--- a/src/events.lua
+++ b/src/events.lua
@@ -122,8 +122,8 @@ end
 
 -- Handle timed alert for non tranqed frenzy
 function TranqRotate:handleTimedAlert()
-    if (TranqRotate.db.profile.enableTimedBackupAlertValue) then
-        C_Timer.After(TranqRotate.db.profile.timedBackupAlertValueDelay, function()
+    if (TranqRotate.db.profile.enableTimedBackupAlert) then
+        C_Timer.After(TranqRotate.db.profile.timedBackupAlertDelay, function()
             if (TranqRotate.frenzy and TranqRotate:isPlayerNextTranq()) then
                 TranqRotate:alertBackup(TranqRotate.db.profile.unableToTranqMessage)
             end

--- a/src/frames.lua
+++ b/src/frames.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 -- Create main window
 function TranqRotate:createMainFrame()
     TranqRotate.mainFrame = CreateFrame("Frame", 'mainFrame', UIParent)

--- a/src/gui.lua
+++ b/src/gui.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 local L = TranqRotate.L
 
 -- Initialize GUI frames. Shouldn't be called more than once

--- a/src/migration.lua
+++ b/src/migration.lua
@@ -1,0 +1,19 @@
+function TranqRotate:migrateProfile()
+
+    if (TranqRotate.db.profile.currentMigration == nil) then
+        TranqRotate.db.profile.currentMigration = 0
+    end
+
+    for i = TranqRotate.db.profile.currentMigration + 1, #TranqRotate.migrations, 1 do
+        TranqRotate.migrations[i]()
+    end
+end
+
+TranqRotate.migrations = {
+    -- 1.6.0
+    function()
+        -- Those are old, badly named key
+        TranqRotate.db.profile.enableTimedBackupAlertValue = nil
+        TranqRotate.db.profile.timedBackupAlertValueDelay = nil
+    end,
+}

--- a/src/migration.lua
+++ b/src/migration.lua
@@ -4,8 +4,11 @@ function TranqRotate:migrateProfile()
         TranqRotate.db.profile.currentMigration = 0
     end
 
-    for i = TranqRotate.db.profile.currentMigration + 1, #TranqRotate.migrations, 1 do
-        TranqRotate.migrations[i]()
+    if (TranqRotate.db.profile.currentMigration < #TranqRotate.migrations) then
+        for i = TranqRotate.db.profile.currentMigration + 1, #TranqRotate.migrations, 1 do
+            TranqRotate.migrations[i]()
+            TranqRotate.db.profile.currentMigration = i
+        end
     end
 end
 

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -463,9 +463,11 @@ function TranqRotate:alertBackup(message, nextHunter, noComms)
             nextHunter = TranqRotate:getNextRotationHunter(player)
         end
 
-        SendChatMessage(message, 'WHISPER', nil, nextHunter.name)
-        if (noComms ~= true) then
-            TranqRotate:sendBackupRequest(nextHunter.name)
+        if (playerName ~= nextHunter.name) then
+            SendChatMessage(message, 'WHISPER', nil, nextHunter.name)
+            if (noComms ~= true) then
+                TranqRotate:sendBackupRequest(nextHunter.name)
+            end
         end
     else
         TranqRotate:whisperBackup(message)

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -11,6 +11,7 @@ function TranqRotate:registerHunter(hunterName)
     hunter.nextTranq = false
     hunter.lastTranqTime = 0
     hunter.lastFailTime = 0
+    hunter.addonVersion = nil
 
     -- Add to global list
     table.insert(TranqRotate.hunterTable, hunter)

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -214,8 +214,8 @@ end
 function TranqRotate:testRotation()
 
     for key, hunter in pairs(TranqRotate.rotationTables.rotation) do
-        if (hunter.nextTranq) then
-            TranqRotate:rotate(hunter, false)
+        if (hunter.nextTranq or key == #TranqRotate.rotationTables.rotation) then
+            TranqRotate:rotate(hunter)
             break
         end
     end

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 local L = TranqRotate.L
 
 -- Adds hunter to global table and one of the two rotation tables

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -497,7 +497,7 @@ function TranqRotate:alertBackup(message, nextHunter, noComms)
             end
         end
     else
-        TranqRotate:whisperBackup(message)
+        TranqRotate:whisperBackup(message, noComms)
     end
 end
 

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -78,13 +78,15 @@ function TranqRotate:rotate(lastHunter, rotateWithoutCooldown)
 end
 
 -- Handle miss or dispel resist scenario
-function TranqRotate:handleFailTranq(hunter)
+function TranqRotate:handleFailTranq(hunter, event)
 
     -- Do not process multiple SPELL_DISPEL_FAILED events or multiple fail broadcasts
     local duplicate = hunter.lastFailTime >=  GetTime() - TranqRotate.constants.duplicateFailedTranqshotDelayThreshold
     if (duplicate) then
         return
     end
+
+    TranqRotate:printFail(hunter, event)
 
     local playerName, realm = UnitName("player")
     local hasPlayerFailed = playerName == hunter.name

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -232,12 +232,20 @@ end
 -- @todo: remove this | TEST FUNCTION - Manually rotate hunters for test purpose
 function TranqRotate:testRotation()
 
+    local hunterToRotate = nil
     for key, hunter in pairs(TranqRotate.rotationTables.rotation) do
-        if (hunter.nextTranq or key == #TranqRotate.rotationTables.rotation) then
-            TranqRotate:rotate(hunter)
+        if (hunter.nextTranq) then
+            hunterToRotate = hunter
             break
         end
     end
+
+    if (not hunterToRotate) then
+        hunterToRotate = TranqRotate.rotationTables.rotation[1]
+    end
+
+    TranqRotate:sendSyncTranq(hunterToRotate, false, timestamp)
+    TranqRotate:rotate(hunterToRotate)
 end
 
 -- Check if a hunter is already registered

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -141,24 +141,24 @@ function TranqRotate:CreateConfig()
                         order = 26,
                         width = "normal",
                         min = 1,
-                        max = 4,
+                        max = 6,
                         step = 0.1,
                     },
-                    enableTimedBackupAlertValue = {
+                    enableTimedBackupAlert = {
                         name = L["ENABLE_AUTOMATIC_TIMED_BACKUP_ALERT"],
                         desc = L["ENABLE_AUTOMATIC_TIMED_BACKUP_ALERT_DESC"],
                         type = "toggle",
                         order = 30,
                         width = "double",
                     },
-                    timedBackupAlertValueDelay = {
+                    timedBackupAlertDelay = {
                         name = L["TIMED_DELAY_THRESHOLD"],
                         desc = L["TIMED_DELAY_THRESHOLD_DESC"],
                         type = "range",
                         order = 31,
                         width = "normal",
                         min = 1,
-                        max = 4,
+                        max = 6,
                         step = 0.1,
                     },
                 }

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -41,18 +41,18 @@ function TranqRotate:CreateConfig()
 						order = 2,
 					},
                     -- @todo : find a way to space widget properly
-					spacer3 = {
-						name = ' ',
-						type = "description",
-						width = "full",
-						order = 3,
-					},
-					baseVersion = {
-						name = L['SETTING_GENERAL_DESC'],
-						type = "description",
-						width = "full",
-						order = 4,
-					},
+					--spacer3 = {
+					--	name = ' ',
+					--	type = "description",
+					--	width = "full",
+					--	order = 3,
+					--},
+					--baseVersion = {
+					--	name = L['SETTING_GENERAL_DESC'],
+					--	type = "description",
+					--	width = "full",
+					--	order = 4,
+					--},
                     -- @todo : find a way to space widget properly
 					spacer4 = {
 						name = ' ',

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -272,3 +272,14 @@ function TranqRotate:formatAddonVersion(version)
         return version
     end
 end
+
+function TranqRotate:printFail(hunter, event)
+    if (event == "SPELL_MISSED") then
+        TranqRotate:printPrefixedMessage(hunter.name .. " missed his tranqshot!")
+    elseif(event == "SPELL_DISPEL_FAILED") then
+        TranqRotate:printPrefixedMessage(hunter.name .. "'s tranqshot was resisted!")
+    else
+        -- v1.5.1 and older do not send the event type
+        TranqRotate:printPrefixedMessage(hunter.name .. "'s tranqshot was missed or resisted!")
+    end
+end

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -2,8 +2,7 @@ TranqRotate = select(2, ...)
 
 local L = TranqRotate.L
 
-local parent = ...
-TranqRotate.version = GetAddOnMetadata(parent, "Version")
+TranqRotate.version = GetAddOnMetadata(..., "Version")
 
 -- Initialize addon - Shouldn't be call more than once
 function TranqRotate:init()

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -70,6 +70,17 @@ end
 
 -- Send a tranq announce message to a given channel
 function TranqRotate:sendAnnounceMessage(message, targetName)
+
+    -- Prints instead to avoid lua error in open world with say and yell
+    if (
+        not IsInInstance() and (
+            TranqRotate.db.profile.channelType == "SAY" or TranqRotate.db.profile.channelType == "YELL"
+        )
+    ) then
+        TranqRotate:printPrefixedMessage(message .. " " .. L["YELL_SAY_DISABLED_OPEN_WORLD"])
+        return
+    end
+
     if TranqRotate.db.profile.enableAnnounces then
         TranqRotate:sendMessage(
             message,
@@ -117,7 +128,7 @@ SlashCmdList["TRANQROTATE"] = function(msg)
     elseif (cmd == 'rotate') then -- @todo decide if this should be removed or not
         TranqRotate:testRotation()
     elseif (cmd == 'test') then -- @todo: remove this
-        TranqRotate:test()
+        TranqRotate:toggleArcaneShotTesting()
     elseif (cmd == 'report') then
         TranqRotate:printRotationSetup()
     elseif (cmd == 'settings') then

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -28,6 +28,7 @@ function TranqRotate:init()
     TranqRotate:initGui()
     TranqRotate:updateRaidStatus()
     TranqRotate:applySettings()
+    TranqRotate:updateDisplay()
     TranqRotate:updateDragAndDrop()
 
     TranqRotate:initComms()
@@ -52,8 +53,6 @@ function TranqRotate:applySettings()
     else
         TranqRotate.mainFrame:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
     end
-
-    TranqRotate:updateDisplay()
 
     TranqRotate.mainFrame:EnableMouse(not TranqRotate.db.profile.lock)
     TranqRotate.mainFrame:SetMovable(not TranqRotate.db.profile.lock)

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -15,6 +15,7 @@ function TranqRotate:init()
     self.db.RegisterCallback(self, "OnProfileReset", "ProfilesChanged")
 
     self:CreateConfig()
+    TranqRotate.migrateProfile()
 
     TranqRotate.hunterTable = {}
     TranqRotate.addonVersions = {}

--- a/src/tranqRotate.lua
+++ b/src/tranqRotate.lua
@@ -17,6 +17,7 @@ function TranqRotate:init()
     self:CreateConfig()
 
     TranqRotate.hunterTable = {}
+    TranqRotate.addonVersions = {}
     TranqRotate.rotationTables = { rotation = {}, backup = {} }
 
     TranqRotate.raidInitialized = false
@@ -132,6 +133,8 @@ SlashCmdList["TRANQROTATE"] = function(msg)
         TranqRotate:printRotationSetup()
     elseif (cmd == 'settings') then
         TranqRotate:openSettings()
+    elseif (cmd == 'check') then
+        TranqRotate:checkVersions()
     else
         TranqRotate:printHelp()
     end
@@ -209,8 +212,9 @@ function TranqRotate:printHelp()
     TranqRotate:printMessage(spacing .. TranqRotate:colorText('lock') .. ' : Lock the main window position')
     TranqRotate:printMessage(spacing .. TranqRotate:colorText('unlock') .. ' : Unlock the main window position')
     TranqRotate:printMessage(spacing .. TranqRotate:colorText('settings') .. ' : Open TranqRotate settings')
-    TranqRotate:printMessage(spacing .. TranqRotate:colorText('report') .. ' : Print the rotation setup to the configured channel')
+    TranqRotate:printMessage(spacing .. TranqRotate:colorText('report') .. ' : Prints the rotation setup to the configured channel')
     TranqRotate:printMessage(spacing .. TranqRotate:colorText('backup') .. ' : Whispers backup hunters to immediately tranq')
+    TranqRotate:printMessage(spacing .. TranqRotate:colorText('check') .. ' : Prints users version of TranqRotate')
 end
 
 -- Adds color to given text
@@ -232,5 +236,39 @@ function TranqRotate:toggleArcaneShotTesting(disable)
     else
         TranqRotate.testMode = false
         TranqRotate:printPrefixedMessage(L['ARCANE_SHOT_TESTING_DISABLED'])
+    end
+end
+
+function TranqRotate:updatePlayerAddonVersion(player, version)
+
+    local hunter = TranqRotate:getHunter(player)
+    if (hunter) then
+        hunter.addonVersion = version
+    else
+        TranqRotate.addonVersions[player] = version
+    end
+end
+
+function TranqRotate:checkVersions()
+    TranqRotate:printPrefixedMessage("## Version check ##")
+    TranqRotate:printPrefixedMessage("You - " .. TranqRotate.version)
+
+    for key, hunter in pairs(TranqRotate.hunterTable) do
+        if (hunter.name ~= UnitName("player")) then
+            TranqRotate:printPrefixedMessage(hunter.name .. " - " .. TranqRotate:formatAddonVersion(hunter.addonVersion))
+        end
+    end
+    for key, player in pairs(TranqRotate.addonVersions) do
+        if (player ~= UnitName("player")) then
+            TranqRotate:printPrefixedMessage(hunter.name .. " - " .. TranqRotate:formatAddonVersion(hunter.addonVersion))
+        end
+    end
+end
+
+function TranqRotate:formatAddonVersion(version)
+    if (version == nil) then
+        return "None or below 1.6.0"
+    else
+        return version
     end
 end

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -1,5 +1,3 @@
-local TranqRotate = select(2, ...)
-
 -- Check if a table contains the given element
 function TranqRotate:tableContains(table, element)
 


### PR DESCRIPTION
- Improves miss and resist tranqshot handling (no more duplicate announces or whispers)
- Adds gluth fear to handled list of incapacitating debuffs
- Adds `/tranq check` command to display the version other users have installed
- Adds printing of fail to chat window
- Fix timed alert feature that never worked (forgot to call it :D), changed default value to disabled
- Fix an ui error when trying to send announces on say/yell channel in open world (test mode)
- Fix windows hiding unexpectedly when changing settings
